### PR TITLE
Move bindings and choosers to OI

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,36 +9,16 @@ import static frc.robot.Constants.LightingConstants.VISPOSE;
 
 import java.io.File;
 
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.Filesystem;
-import edu.wpi.first.wpilibj.RobotController;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.robot.Constants.AutoConstants.AutoPattern;
 import frc.robot.Constants.OiConstants;
-import frc.robot.commands.CancelCommand;
-import frc.robot.commands.arm.AimAmpCommand;
-import frc.robot.commands.arm.AimSpeakerCommand;
-import frc.robot.commands.arm.CompactPoseCommand;
 import frc.robot.commands.arm.DefaultArmCommand;
-import frc.robot.commands.arm.ShootCommand;
-import frc.robot.commands.arm.StartIntakeCommand;
-import frc.robot.commands.auto.*;
 import frc.robot.commands.climb.DefaultClimbCommand;
 import frc.robot.commands.operator.OperatorInput;
-import frc.robot.commands.swervedrive.DriveToPositionCommand;
-import frc.robot.commands.swervedrive.RotateToTargetCommand;
 import frc.robot.commands.swervedrive.TeleopDriveCommand;
-import frc.robot.commands.swervedrive.ZeroGyroCommand;
-import frc.robot.commands.test.SystemTestCommand;
 import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.ClimbSubsystem;
 import frc.robot.subsystems.lighting.LightingSubsystem;
-import frc.robot.subsystems.lighting.pattern.Enabled;
 import frc.robot.subsystems.swerve.SwerveSubsystem;
 import frc.robot.subsystems.swerve.yagsl.YagslSubsystem;
 import frc.robot.subsystems.vision.HughVisionSubsystem;
@@ -58,23 +38,20 @@ public class RobotContainer {
 
     // The robot's subsystems and commands are defined here...
 
-    private final HughVisionSubsystem    hugh               = new HughVisionSubsystem();
-    private final JackmanVisionSubsystem jackman            = new JackmanVisionSubsystem();
-    private final LightingSubsystem      lighting           = new LightingSubsystem(SIGNAL, VISPOSE);
-    private final ArmSubsystem           arm                = new ArmSubsystem(lighting);
-    private final ClimbSubsystem         climb              = new ClimbSubsystem(lighting);
-
-    // todo: set up sendable chooser for this to toggle implementation for testing
-    private final File                   yagslConfig        = new File(Filesystem.getDeployDirectory(), "swerve/neo");
-    private final SwerveSubsystem        drive              = new YagslSubsystem(yagslConfig, hugh,
+    private final HughVisionSubsystem    hugh          = new HughVisionSubsystem();
+    private final JackmanVisionSubsystem jackman       = new JackmanVisionSubsystem();
+    private final LightingSubsystem      lighting      = new LightingSubsystem(SIGNAL, VISPOSE);
+    private final ArmSubsystem           arm           = new ArmSubsystem(lighting);
+    private final ClimbSubsystem         climb         = new ClimbSubsystem(lighting);
+    private final File                   yagslConfig   = new File(Filesystem.getDeployDirectory(), "swerve/neo");
+    private final SwerveSubsystem        drive         = new YagslSubsystem(yagslConfig, hugh,
         lighting);
 //    private final SwerveSubsystem        drive   = new RunnymedeSwerveSubsystem(hughVisionSubsystem,
 //        lightingSubsystem);
 
-    SendableChooser<AutoPattern>         autoPatternChooser = new SendableChooser<>();
-
-    private final OperatorInput          operatorInput      = new OperatorInput(
-        OiConstants.DRIVER_CONTROLLER_PORT, OiConstants.OPERATOR_CONTROLLER_PORT);
+    private final OperatorInput          operatorInput = new OperatorInput(
+        OiConstants.DRIVER_CONTROLLER_PORT, OiConstants.OPERATOR_CONTROLLER_PORT,
+        drive, arm, climb, hugh, jackman, lighting);
 
     /**
      * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -85,95 +62,12 @@ public class RobotContainer {
         arm.setDefaultCommand(new DefaultArmCommand(operatorInput, arm));
         climb.setDefaultCommand(new DefaultClimbCommand(operatorInput, climb));
 
-        configureTriggerBindings();
-        initAutoSelectors();
+        operatorInput.configureTriggerBindings();
+        operatorInput.initAutoSelectors();
     }
 
-    private void initAutoSelectors() {
-
-        // FIXME: (low) consider moving all of the choosers to their own classes.
-        SmartDashboard.putData("Auto Pattern", autoPatternChooser);
-        autoPatternChooser.setDefaultOption("Do Nothing", AutoPattern.DO_NOTHING);
-
-        autoPatternChooser.addOption("1 Amp", AutoPattern.SCORE_1_AMP);
-        autoPatternChooser.addOption("2 Amp", AutoPattern.SCORE_2_AMP);
-        autoPatternChooser.addOption("2.5 Amp", AutoPattern.SCORE_2_5_AMP);
-
-        autoPatternChooser.addOption("1 Speaker", AutoPattern.SCORE_1_SPEAKER);
-        autoPatternChooser.addOption("3 Speaker", AutoPattern.SCORE_3_SPEAKER);
-        autoPatternChooser.addOption("4 Speaker", AutoPattern.SCORE_4_SPEAKER);
-
-        autoPatternChooser.addOption("Plan B", AutoPattern.PLAN_B);
-    }
-
-    /**
-     * Use this method to define your trigger->command mappings. Triggers can be created via the
-     * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with
-     * an arbitrary predicate, or via the named factories in {@link
-     * edu.wpi.first.wpilibj2.command.button.CommandGenericHID}'s subclasses for
-     * {@link CommandXboxController Xbox} /
-     * {@link edu.wpi.first.wpilibj2.command.button.CommandPS4Controller PS4} controllers or
-     * {@link edu.wpi.first.wpilibj2.command.button.CommandJoystick Flight joysticks}.
-     */
-    private void configureTriggerBindings() {
-
-        // Run when enabled
-        new Trigger(RobotController::isSysActive).onTrue(new InstantCommand(() -> lighting.addPattern(Enabled.getInstance())));
-
-        // Activate test mode
-        new Trigger(operatorInput::isToggleTestMode).onTrue(new SystemTestCommand(operatorInput, drive, arm, lighting));
-
-        new Trigger(operatorInput::isZeroGyro).onTrue(new ZeroGyroCommand(drive));
-        new Trigger(operatorInput::isCancel).whileTrue(new CancelCommand(operatorInput, drive, arm, climb));
-        new Trigger(operatorInput::isB).onTrue(RotateToTargetCommand.createRotateToSpeakerCommand(drive, hugh));
-
-        // Compact
-        new Trigger(operatorInput::isCompactPressed).onTrue(new CompactPoseCommand(arm));
-
-        // Start Intake
-        new Trigger(operatorInput::isStartIntake).onTrue(new StartIntakeCommand(arm));
-
-        // Aim Amp
-        new Trigger(operatorInput::isAimAmp).onTrue(new AimAmpCommand(arm));
-
-        // Aim Speaker
-        new Trigger(operatorInput::isAimSpeaker).onTrue(new AimSpeakerCommand(arm, hugh));
-
-        // Shoot
-        new Trigger(operatorInput::isShoot).onTrue(new ShootCommand(arm));
-
-        // Test Drive to 2,2
-
-        new Trigger(operatorInput::isX)
-            .onTrue(new DriveToPositionCommand(drive, new Translation2d(2, 2), new Translation2d(14.54, 2)));
-
-        // Climbs Up pov 0
-        // Climbs Down pov 180
-        // Climbs Down pov 270
-        // Trap pov 90
-        // Shift to Climb right bumper
-
-    }
-
-    /**
-     * Use this to pass the autonomous command to the main {@link Robot} class.
-     *
-     * @return the command to run in autonomous
-     */
     public Command getAutonomousCommand() {
-
-        return switch (autoPatternChooser.getSelected()) {
-        case SCORE_1_AMP -> new Score1AmpAutoCommand(drive, hugh);
-        case SCORE_2_AMP -> new Score2AmpAutoCommand(drive, arm, hugh, jackman);
-        case SCORE_2_5_AMP -> new Score2_5AmpAutoCommand(drive, arm, hugh, jackman);
-        case SCORE_1_SPEAKER -> new Score1SpeakerAutoCommand(drive, hugh);
-        case SCORE_3_SPEAKER -> new Score3SpeakerAutoCommand(drive, arm, hugh, jackman);
-        case SCORE_4_SPEAKER -> new Score4SpeakerAutoCommand(drive, arm, hugh, jackman);
-        case PLAN_B -> new PlanBAutoCommand(drive);
-        // If the chooser did not work, then do nothing as the default auto.
-        default -> new InstantCommand();
-        };
-
+        return operatorInput.getAutonomousCommand();
     }
 
 }

--- a/src/main/java/frc/robot/commands/operator/OperatorInput.java
+++ b/src/main/java/frc/robot/commands/operator/OperatorInput.java
@@ -1,15 +1,49 @@
 package frc.robot.commands.operator;
 
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants;
+import frc.robot.Robot;
+import frc.robot.commands.CancelCommand;
+import frc.robot.commands.arm.*;
+import frc.robot.commands.auto.*;
+import frc.robot.commands.swervedrive.DriveToPositionCommand;
+import frc.robot.commands.swervedrive.RotateToTargetCommand;
+import frc.robot.commands.swervedrive.ZeroGyroCommand;
+import frc.robot.commands.test.SystemTestCommand;
+import frc.robot.subsystems.ArmSubsystem;
+import frc.robot.subsystems.ClimbSubsystem;
+import frc.robot.subsystems.lighting.LightingSubsystem;
+import frc.robot.subsystems.lighting.pattern.Enabled;
+import frc.robot.subsystems.swerve.SwerveSubsystem;
+import frc.robot.subsystems.vision.HughVisionSubsystem;
+import frc.robot.subsystems.vision.JackmanVisionSubsystem;
+
+import static frc.robot.Constants.UsefulPoses.BLUE_2_2_20;
+import static frc.robot.Constants.UsefulPoses.RED_2_2_20;
 
 /**
  * The DriverController exposes all driver functions
  */
 public class OperatorInput {
 
-    private final XboxController driverController;
-    private final XboxController operatorController;
+    private final SwerveSubsystem                                      drive;
+    private final ArmSubsystem                                         arm;
+    private final LightingSubsystem                                    lighting;
+    private final HughVisionSubsystem                                  hugh;
+    private final ClimbSubsystem                                       climb;
+    private final JackmanVisionSubsystem                               jackman;
+    private final XboxController                                       driverController;
+    private final XboxController                                       operatorController;
+
+    private final SendableChooser<Constants.AutoConstants.AutoPattern> autoPatternChooser = new SendableChooser<>();
 
     public enum Stick {
         LEFT, RIGHT
@@ -28,19 +62,27 @@ public class OperatorInput {
      * @param operatorControllerPort on the driver station which the aux joystick is
      * plugged into
      */
-    public OperatorInput(int driverControllerPort, int operatorControllerPort) {
+    public OperatorInput(int driverControllerPort, int operatorControllerPort, SwerveSubsystem drive, ArmSubsystem arm,
+        ClimbSubsystem climb, HughVisionSubsystem hugh, JackmanVisionSubsystem jackman, LightingSubsystem lighting) {
+        this.drive         = drive;
+
+        this.arm           = arm;
+        this.lighting      = lighting;
+        this.hugh          = hugh;
+        this.climb         = climb;
+        this.jackman       = jackman;
+
         driverController   = new RunnymedeGameController(driverControllerPort);
         operatorController = new RunnymedeGameController(operatorControllerPort);
-    }
-
-    public boolean isToggleTestMode() {
-        return !DriverStation.isFMSAttached() && driverController.getBackButton() && driverController.getStartButton();
     }
 
     public XboxController getRawDriverController() {
         return driverController;
     }
 
+    public int getDriverPOV() {
+        return driverController.getPOV();
+    }
 
     public boolean isDriverLeftBumper() {
         return driverController.getLeftBumper();
@@ -50,111 +92,136 @@ public class OperatorInput {
         return driverController.getRightBumper();
     }
 
-    // Testing purposes only
-    public boolean isA() {
-        return driverController.getAButton();
-    }
-
-    public boolean isFaceSpeaker() {
+    public boolean isDriveFacingSpeaker() {
         return driverController.getYButton();
-    }
-
-    public boolean isX() {
-        return driverController.getXButton();
-    }
-
-    public boolean isB() {
-        return driverController.getBButton();
-    }
-
-    public boolean isLock() {
-        return driverController.getXButton();
-    }
-
-    public boolean isZeroGyro() {
-        return driverController.getBackButton();
     }
 
     public boolean isCancel() {
         return driverController.getStartButton();
     }
 
-    public boolean isCompactPressed() {
-        return driverController.getXButton() || operatorController.getXButton();
-    }
-
-    public boolean isStartIntake() {
-        return driverController.getAButton();
-    }
-
-    public boolean isAimAmp() {
-        return operatorController.getAButton();
-    }
-
-    public boolean isAimSpeaker() {
-        return operatorController.getYButton();
-    }
-
-    public boolean isShoot() {
-        return operatorController.getBButton();
-    }
-
     public boolean isShift() {
         return operatorController.getRightBumper();
     }
 
-    public int getPOV() {
-        return driverController.getPOV();
-    }
-
     public double getDriverControllerAxis(Stick stick, Axis axis) {
 
-        switch (stick) {
+        return switch (stick) {
+        case LEFT -> switch (axis) {
+        case X -> driverController.getLeftX();
+        case Y -> driverController.getLeftY();
+        };
+        case RIGHT -> switch (axis) {
+        case X -> driverController.getRightX();
+        case Y -> driverController.getRightY();
+        };
+        };
 
-        case LEFT:
-            switch (axis) {
-            case X:
-                return driverController.getLeftX();
-            case Y:
-                return driverController.getLeftY();
-            }
-            break;
-
-        case RIGHT:
-            switch (axis) {
-            case X:
-                return driverController.getRightX();
-            }
-            break;
-        }
-
-        return 0;
     }
 
     public double getOperatorControllerAxis(Stick stick, Axis axis) {
 
-        switch (stick) {
+        return switch (stick) {
+        case LEFT -> switch (axis) {
+        case X -> operatorController.getLeftX();
+        case Y -> operatorController.getLeftY();
+        };
+        case RIGHT -> switch (axis) {
+        case X -> operatorController.getRightX();
+        case Y -> operatorController.getRightY();
+        };
+        };
 
-        case LEFT:
-            switch (axis) {
-            case X:
-                return operatorController.getLeftX();
-            case Y:
-                return operatorController.getLeftY();
-            }
-            break;
+    }
 
-        case RIGHT:
-            switch (axis) {
-            case X:
-                return operatorController.getRightX();
-            case Y:
-                return operatorController.getRightY();
-            }
-            break;
-        }
 
-        return 0;
+    /**
+     * Use this method to define your trigger->command mappings. Triggers can be created via the
+     * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with
+     * an arbitrary predicate, or via the named factories in {@link
+     * edu.wpi.first.wpilibj2.command.button.CommandGenericHID}'s subclasses for
+     * {@link CommandXboxController Xbox} /
+     * {@link edu.wpi.first.wpilibj2.command.button.CommandPS4Controller PS4} controllers or
+     * {@link edu.wpi.first.wpilibj2.command.button.CommandJoystick Flight joysticks}.
+     */
+    public void configureTriggerBindings() {
+
+        // Run when enabled
+        new Trigger(RobotController::isSysActive).onTrue(new InstantCommand(() -> lighting.addPattern(Enabled.getInstance())));
+
+        // Activate test mode
+        new Trigger(() -> !DriverStation.isFMSAttached() && driverController.getBackButton() && driverController.getStartButton())
+            .onTrue(new SystemTestCommand(this, drive, arm, lighting));
+
+        // Cancel all systems
+        new Trigger(this::isCancel).whileTrue(new CancelCommand(this, drive, arm, climb));
+
+        // zero gyro
+        new Trigger(driverController::getBackButton).onTrue(new ZeroGyroCommand(drive));
+
+        // Rotate to speaker
+        new Trigger(driverController::getBButton).onTrue(RotateToTargetCommand.createRotateToSpeakerCommand(drive, hugh));
+
+        // Compact
+        new Trigger(() -> driverController.getXButton() || operatorController.getXButton()).onTrue(new CompactPoseCommand(arm));
+
+        // Start Intake
+        new Trigger(driverController::getAButton).onTrue(new StartIntakeCommand(arm));
+
+        // Aim Amp
+        new Trigger(operatorController::getAButton).onTrue(new AimAmpCommand(arm));
+
+        // Aim Speaker
+        new Trigger(operatorController::getYButton).onTrue(new AimSpeakerCommand(arm, hugh));
+
+        // Shoot
+        new Trigger(operatorController::getBButton).onTrue(new ShootCommand(arm));
+
+        // Test Drive to 2,2,20
+        new Trigger(driverController::getXButton).onTrue(new DriveToPositionCommand(drive, BLUE_2_2_20, RED_2_2_20));
+
+        // Climbs Up pov 0
+        // Climbs Down pov 180
+        // Climbs Down pov 270
+        // Trap pov 90
+        // Shift to Climb right bumper
+
+    }
+
+    public void initAutoSelectors() {
+
+        SmartDashboard.putData("Auto Pattern", autoPatternChooser);
+
+        autoPatternChooser.setDefaultOption("Do Nothing", Constants.AutoConstants.AutoPattern.DO_NOTHING);
+
+        autoPatternChooser.addOption("1 Amp", Constants.AutoConstants.AutoPattern.SCORE_1_AMP);
+        autoPatternChooser.addOption("2 Amp", Constants.AutoConstants.AutoPattern.SCORE_2_AMP);
+        autoPatternChooser.addOption("2.5 Amp", Constants.AutoConstants.AutoPattern.SCORE_2_5_AMP);
+
+        autoPatternChooser.addOption("1 Speaker", Constants.AutoConstants.AutoPattern.SCORE_1_SPEAKER);
+        autoPatternChooser.addOption("3 Speaker", Constants.AutoConstants.AutoPattern.SCORE_3_SPEAKER);
+        autoPatternChooser.addOption("4 Speaker", Constants.AutoConstants.AutoPattern.SCORE_4_SPEAKER);
+
+        autoPatternChooser.addOption("Plan B", Constants.AutoConstants.AutoPattern.PLAN_B);
+    }
+
+    /**
+     * Use this to pass the autonomous command to the main {@link Robot} class.
+     *
+     * @return the command to run in autonomous
+     */
+    public Command getAutonomousCommand() {
+
+        return switch (autoPatternChooser.getSelected()) {
+        case SCORE_1_AMP -> new Score1AmpAutoCommand(drive, hugh);
+        case SCORE_2_AMP -> new Score2AmpAutoCommand(drive, arm, hugh, jackman);
+        case SCORE_2_5_AMP -> new Score2_5AmpAutoCommand(drive, arm, hugh, jackman);
+        case SCORE_1_SPEAKER -> new Score1SpeakerAutoCommand(drive, hugh);
+        case SCORE_3_SPEAKER -> new Score3SpeakerAutoCommand(drive, arm, hugh, jackman);
+        case SCORE_4_SPEAKER -> new Score4SpeakerAutoCommand(drive, arm, hugh, jackman);
+        case PLAN_B -> new PlanBAutoCommand(drive);
+        default -> new InstantCommand();
+        };
     }
 
 }

--- a/src/main/java/frc/robot/commands/swervedrive/TeleopDriveCommand.java
+++ b/src/main/java/frc/robot/commands/swervedrive/TeleopDriveCommand.java
@@ -82,9 +82,9 @@ public class TeleopDriveCommand extends BaseDriveCommand {
         // User wants to jump directly to a specific heading. Computation is deferred because it is
         // complex
         // and may not be necessary. See below for details.
-        final int           rawDesiredHeadingDeg         = oi.getPOV();
+        final int           rawDesiredHeadingDeg         = oi.getDriverPOV();
 
-        final boolean       faceSpeaker                  = oi.isFaceSpeaker();
+        final boolean       faceSpeaker                  = oi.isDriveFacingSpeaker();
         final Translation2d speaker                      = alliance == Alliance.Blue
             ? Constants.BotTarget.BLUE_SPEAKER.getLocation().toTranslation2d()
             : Constants.BotTarget.RED_SPEAKER.getLocation().toTranslation2d();


### PR DESCRIPTION
Move bindings and choosers to Operator Input. This centralizes all operator input into a single class, and eliminates the need to coordinate controller method names between 2 classes.